### PR TITLE
Fixed Exec['augenrules'] to be a string command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### 1.0.3
+
+* Fixed Exec['augenrules'] to be a string command
+
 #### 1.0.2
 
 * Changed functionality to use augenrules binary and place configs in /etc/audit/rules.d/ instead of /etc/audit/audit.rules

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,7 +21,7 @@ class auditd::config inherits auditd {
   }
 
   exec { 'augenrules':
-    command     => ['/sbin/augenrules', '--load'],
+    command     => '/sbin/augenrules --load',
     user        => $auditd::auditd_rules_file_owner,
     refreshonly => true,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ubeek-auditd",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Levi Jarick",
   "summary": "Configures auditd and add some standard rule",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -37,7 +37,7 @@ describe 'auditd::config', type: :class do
         'content' => %r{# Identity changes\n-w /etc/group -p wa -k identity}
       )
       is_expected.to contain_exec('augenrules').with(
-        'command'     => ['/sbin/augenrules', '--load'],
+        'command'     => '/sbin/augenrules --load',
         'user'        => 'root',
         'refreshonly' => 'true',
       )


### PR DESCRIPTION
Exec['augenrules'] is failing puppet compile; expecting a string value not array